### PR TITLE
Add manual "mark spam" button for admins

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 # set DEPLOY_ENVIRONMENT in config.mk
+# The rain in Spain
 DEPLOY_ENVIRONMENT := dev
 
 DOCKER_SHARED_DIR=docker/shared

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The Computational Model Library maintains distinct submission information packag
 Members who participate in this project agree to abide by the [CoMSES Net Code of Conduct](https://github.com/comses/comses.net/blob/main/CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report unacceptable behavior to [editors@comses.net](mailto:editors@comses.net).
 
 ## Ways to Contribute to CoMSES Net
-
+The rain in Spain falls mainly on the plain.
 Members are encouraged to participate and we welcome contributions of all kinds to our collective effort. Here's how you can contribute:
 
 ### Publish your Model Source Code

--- a/django/core/jinja2/common.jinja
+++ b/django/core/jinja2/common.jinja
@@ -336,6 +336,32 @@ Currently in <em><mark>{{ constants.DEPLOY_ENVIRONMENT }}</mark></em> mode.
 {% endif %}
 {% endmacro %}
 
+{% macro mark_spam_confirm_modal(modal_title, identifier, mark_spam_url, csrf_input) %}
+<button type="button" class="btn btn-danger my-1 w-100" data-bs-toggle="modal" data-bs-target="#mark-spam-modal">
+    Mark spam
+</button>
+<div class="modal fade" id="mark-spam-modal" tabindex="-1" aria-labelledby="mark-spam-label" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h1 class="modal-title fs-5" id="mark-spam-label">{{ modal_title }}</h1>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <p>Are you sure you want to mark "<b>{{ identifier }}</b>" as spam?</p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-outline-gray" data-bs-dismiss="modal">Cancel</button>
+                <form method="post" action="{{ mark_spam_url }}">
+                    {{ csrf_input }}
+                    <button type="submit" class="btn btn-danger">Mark as spam</button>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+{% endmacro %}
+
 {% macro alert_if_deleted(is_deleted, content_type="content") %}
 {% if is_deleted %}
     <div class="alert alert-danger" role="alert">

--- a/django/core/jinja2/core/events/retrieve.jinja
+++ b/django/core/jinja2/core/events/retrieve.jinja
@@ -1,5 +1,5 @@
 {% extends "sidebar_layout.jinja" %}
-{% from "common.jinja" import breadcrumb, embed_discourse_comments, share_card, member_profile_href, search_tag_href, delete_confirm_modal, render_ogp_tags, alert_if_spam, alert_if_deleted %}
+{% from "common.jinja" import breadcrumb, embed_discourse_comments, share_card, member_profile_href, search_tag_href, delete_confirm_modal, render_ogp_tags, alert_if_spam, alert_if_deleted, mark_spam_confirm_modal %}
 
 {% block title %}{{ title }}{% endblock %}
 
@@ -75,6 +75,7 @@
         <a href="{{ url('core:event-edit', pk=id) }}">
             <div class="btn btn-primary my-1 w-100">Edit</div>
         </a>
+        {{ mark_spam_confirm_modal("Mark spam", title, url("core:event-manually-mark-spam", pk=id), csrf_input) }}
     {% endif %}
     {% if has_delete_perm %}
         {{ delete_confirm_modal("Delete Event", title, url("core:event-delete", pk=id), csrf_input) }}

--- a/django/core/jinja2/core/jobs/retrieve.jinja
+++ b/django/core/jinja2/core/jobs/retrieve.jinja
@@ -1,5 +1,5 @@
 {% extends "sidebar_layout.jinja" %}
-{% from "common.jinja" import permission_button_group, breadcrumb, embed_discourse_comments, share_card, member_profile_href, search_tag_href, delete_confirm_modal, render_ogp_tags, alert_if_spam, alert_if_deleted %}
+{% from "common.jinja" import permission_button_group, breadcrumb, embed_discourse_comments, share_card, member_profile_href, search_tag_href, delete_confirm_modal, render_ogp_tags, alert_if_spam, alert_if_deleted, mark_spam_confirm_modal %}
 
 {% block title %}{{ title }}{% endblock %}
 
@@ -69,6 +69,7 @@
         <a href="{{ url('core:job-edit', pk=id) }}">
             <div class="btn btn-primary my-1 w-100">Edit</div>
         </a>
+        {{ mark_spam_confirm_modal("Mark spam", title, url("core:job-manually-mark-spam", pk=id), csrf_input) }}
     {% endif %}
     {% if has_delete_perm %}
         {{ delete_confirm_modal("Delete Job Posting", title, url("core:job-delete", pk=id), csrf_input) }}

--- a/django/core/mixins.py
+++ b/django/core/mixins.py
@@ -4,10 +4,12 @@ from django.conf import settings
 from django.contrib.auth.views import redirect_to_login
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import PermissionDenied
+from django.shortcuts import redirect
 from django.utils import timezone
 from rest_framework import serializers
 from rest_framework.exceptions import NotFound
 from rest_framework.response import Response
+from rest_framework.decorators import action
 
 from .models import SpamModeration
 from .permissions import ViewRestrictedObjectPermissions
@@ -267,6 +269,30 @@ class SpamCatcherViewSetMixin:
                 raise ValueError(
                     f"instance {instance} does not have a {field} attribute"
                 )
+
+    @action(detail=True, methods=["post"])
+    def manually_mark_spam(self, request, **kwargs):
+        # consider adding notes field to the request
+        # notes = request.data.get("notes")
+        instance = self.get_object()
+        self._validate_content_object(instance)
+        content_type = ContentType.objects.get_for_model(type(instance))
+        spam_moderation, created = SpamModeration.objects.get_or_create(
+            content_type=content_type,
+            object_id=instance.id,
+            defaults={
+                "status": SpamModeration.Status.SPAM,
+                "detection_method": "manual",
+                "reviewer": request.user,
+            },
+        )
+        if not created:
+            spam_moderation.status = SpamModeration.Status.SPAM
+            spam_moderation.detection_method = "manual"
+            spam_moderation.reviewer = request.user
+            spam_moderation.save()
+        # return Response({"message": "Successfully marked as spam!"}, status=status.HTTP_200_OK)
+        return redirect(instance.get_list_url())
 
     def handle_spam_detection(self, serializer: serializers.Serializer):
         if "spam_context" in serializer.context:

--- a/django/core/tests/test_views.py
+++ b/django/core/tests/test_views.py
@@ -9,8 +9,9 @@ from django.test import TestCase
 from core.tests.base import UserFactory
 from core.tests.permissions_base import BaseViewSetTestCase
 from core.views import EventViewSet, JobViewSet
-from core.models import Job, Event
+from core.models import Job, Event, SpamModeration
 from .base import JobFactory, EventFactory
+
 
 logger = logging.getLogger(__name__)
 
@@ -178,6 +179,30 @@ class SpamDetectionTestCase(BaseViewSetTestCase):
         self.assertTrue(job.is_marked_spam)
         self.assertIsNotNone(job.spam_moderation)
         self.assertEqual(job.spam_moderation.detection_method, "form_submit_time")
+
+    def test_manually_mark_spam(self):
+        data = self.event_factory.get_request_data()
+        # create Job or Event (ModeratedContent)
+        response = self.client.post(
+            reverse("core:event-list"),
+            data,
+            HTTP_ACCEPT="application/json",
+            format="json",
+        )
+        event = Event.objects.get(title=data["title"])
+        self.assertFalse(event.is_marked_spam)
+        self.assertIsNone(event.spam_moderation)
+        response = self.client.post(
+            reverse("core:event-manually-mark-spam", kwargs={"pk": event.id}),
+            data,
+            HTTP_ACCEPT="application/json",
+            format="json",
+        )
+        event.refresh_from_db()
+        self.assertTrue(event.is_marked_spam)
+        self.assertIsNotNone(event.spam_moderation)
+        self.assertEqual(event.spam_moderation.status, SpamModeration.Status.SPAM)
+
 
     def test_event_creation_without_spam(self):
         data = self.event_factory.get_request_data()

--- a/django/library/jinja2/library/codebases/releases/retrieve.jinja
+++ b/django/library/jinja2/library/codebases/releases/retrieve.jinja
@@ -1,5 +1,5 @@
 {% extends "sidebar_layout.jinja" %}
-{% from "common.jinja" import breadcrumb, embed_discourse_comments, share_card, search_tag_href, member_profile_href, render_ogp_tags, alert_if_spam %}
+{% from "common.jinja" import breadcrumb, embed_discourse_comments, share_card, search_tag_href, member_profile_href, render_ogp_tags, alert_if_spam, mark_spam_confirm_modal %}
 {% from "library/review/includes/macros.jinja" import include_review_reminders, confirm_change_closed_modal %}
 
 {% set open_code_badge_png_url = request.build_absolute_uri(static("images/icons/open-code-badge.png")) %}
@@ -465,6 +465,7 @@
         {% endif %}
     {% endwith %}
     {# end has_change_perm #}
+    {{ mark_spam_confirm_modal("Mark spam", codebase.title, url("library:codebase-manually-mark-spam", identifier=codebase.identifier), csrf_input) }}
 {% endif %}
 {% with review=release.get_review() %}
     {% if review %}


### PR DESCRIPTION

Should apply to Events, Jobs, Codebases, and MemberProfiles

will need a new function to do essentially the same thing as handle_spam_detection in https://github.com/comses/comses.net/blob/45644e15f1b8c61554b45f6186a31aae9ed875d6/django/core/mixins.py#L271-L295 but with the fields:

spam_detection: SpamModeration.Status.SPAM
detection_method: "manual"
detection_details: any other context? maybe the user that marked it?
the logic should ideally be in a generic (meaning not tied to any specific content model) view with a url of something like /mark-spam/<content_type>/<content_id> and then have a generic template macro which renders a button that posts to this url and can be included on detail pages somewhere around the sidebar

needs to be secured such that only admins can see the button and post to the url